### PR TITLE
Enh/readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm build-all
 ```
 
 
-## Project-Structure
+## Project structure
 This is roughly how the sub projects are structured
 ![Project structure](https://user-images.githubusercontent.com/83574/59567501-b88a0000-903c-11e9-98b7-df1dbd4a65c6.png "Project structure")
 

--- a/README.md
+++ b/README.md
@@ -22,38 +22,6 @@ npm install-all
 // Build all child projects
 npm build-all
 ```
-## Angular-Pega
-
-After pulling the project, run the following command in the Angular project directory in the terminal. 
-```
-//Generates the artifacts containing the Angular project's source code, the --prod tag only generates the three necessary files to be used in Pega
-ng build --prod
-```
-The three files will be generated in the dist subfolder of the Angular project. They will be titled "main", "polyfill"
-"runtime", use the ECMAScript 5 version of the files instead of the 2015 version of the files. There will be an additional css file generated with the three relevant generated files. 
-
-Login into Dev Studio lu-84 system and add the "Ngtracer" branch. 
-
-In the "Text File" tab of the NG-Tracer branch, there are 4 files titled with the prefix "webwb pztracer-ng". Copy and paste the contents of the ECMAScript 5 version of the files generated into their respective text files.  
-
-  To save the changes to the content of a text file, click the the blue "Check out" button in the top right corner and to save the
-  changes made, clicke the blue "Save" button that has replaced the "Check out" button. Then click the gray "Check in" button
-  to make the changes visible to everyone else with access to the branch. 
-
-In the "Section" tab of the NG-Tracer branch, click the tab called "pzTracerViwerSessionConfig". In the HTML Source textbox, paste this HTML script into the textbox.
-```
-  <script>
-    localStorage.connectionId = "<pega:reference mode="normal" name="pxRequestor.pxClientConnection"/>";
-      localStorage.nodeId = "<pega:reference mode="normal" name="pxProcess.pxSystemNodeID"/>";
-  </script>
-  <pega:static type="script" app="webwb" >
-	  <pega:bundle name="pztracer-ng" />
-  </pega:static>
-```
-
-Checkout and save and then checkin the changes the same way the the four previous text files were altered. 
-
-In the bottom tab of the page where the "Tracer" button normally is, there will be a new button titled "NG Tracer" right next to it, click it and it will emulate how the original tracer works. 
 
 
 ## Project-Structure
@@ -66,6 +34,11 @@ This is roughly how the sub projects are structured
 The tracer client project provides 
 
 [README](https://github.com/pegasystems/tracer-client/tree/master/tracer-client)
+
+## tracer-view-classic
+The classic tracer UI built using the tracer client interface.
+
+[README](https://github.com/pegasystems/tracer-client/tree/master/tracer-view-classic)
 
 ## dev-tools 
 Development tools to facilitate Tracer development, specifically without

--- a/tracer-view-classic/README.md
+++ b/tracer-view-classic/README.md
@@ -1,27 +1,73 @@
-# TracerViewClassic
+# Tracer View Classic
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 8.0.2.
+Tracer view classic is a UI for the tracer using the tracer-client interface which tries to demonstrate all of the existing features of the tracer in a very familiar interface.
 
-## Development server
+As this project begins to diverge from the existing tracer we'll likely rename it.
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+## Local development
+This project comes bundled with a sample trace output file so you can start development without a Pega environemnt.
+To do so, execute the following commants
+```
+// after cloning the repository
 
-## Code scaffolding
+npm install
+npm run install-all
+npm start-trace-file-server
+cd tracer-view-classic
+ng serve
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+// navigate to localhost:4200
+```
 
-## Build
+## Using this project in a Pega environment
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+There is a branch we have been using that allows us to load the project output into the Dev Studio. 
 
-## Running unit tests
+This branch is not yet available for distribution but for posterity, or if some one would like to replicate it,
+ the branch 
+has the following structure:
+  - *Harness*: pzTracerViewer
+    - *Text File*: pztracer-ng-styles.css
+    - *Section*: pzTracerViewer
+      - *Section*: pzTracerViewerSessionConfig
+        - Text file: pztracer-ng-main-es5.js
+        - Text File: pztracer-ng-pollyfills-es5.js
+        - Text file: pztracer-ng-runtime-es5.js
+      - *Section*: pzTracerViewerMain
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+*Note: It is important that the session config code executes before the compiled angular text files.*
 
-## Running end-to-end tests
+#### pzTracerViewerMain
+```
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="icon" type="image/x-icon" href="favicon.ico">
+<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+<app-root></app-root>
+```
 
-Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
 
-## Further help
+#### pzTracerVeiwerSessionConfig
+```
+<script>
+  localStorage.connectionId = "<pega:reference mode="normal" name="pxRequestor.pxClientConnection"/>";
+    localStorage.nodeId = "<pega:reference mode="normal" name="pxProcess.pxSystemNodeID"/>";
+</script>
+<pega:static type="script" app="webwb" >
+	<pega:bundle name="pztracer-ng" />
+</pega:static>
+```
 
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+
+## Updating the NG-Tracer branch with the latest build from source
+Run the following command in the tracer-view-classic sub-project. 
+```
+ng build --prod
+```
+The compiled angular application will be generated in the project's `dist` folder. There should be three 
+javascript files titled `main`, `polyfill` and `runtime`; use the ECMAScript 5 version of the files 
+instead of the 2015 version of the files. There will be an additional css file generated in the same 
+directory. 
+
+Copy the contents of these four generated files into the text file rules within the Dev Studio with the 
+corresponding names.


### PR DESCRIPTION
Did a bit of cleanup to the readme.

- Moved the tracer-view-classic documentation out of the top level readme and into it's own.
- Removed the angular boilerplate readme from the tracer-view-classic project
- Cleaned up a lot of the Dev-Studio specific instructions.
- Removed references to internal Pega servers and branches.